### PR TITLE
Remove incidental foounit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "maquillage": "0.0.4",
     "rxjs": "^5.0.0-beta.7",
     "shell-quote": "^1.6.0",
-    "triejs": "^0.1.5",
+    "triejs-but-without-foounit-as-a-prod-dep": "^0.1.5",
     "yargs": "^4.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`Foounit` makes it hard to build lobar on newer node versions, etc. 
Unfortunately, `triejs` includes it as a prod dependency.
This should be a simple fix.