### PR TITLE
Cast lodash as an object

### DIFF
--- a/src/eval.js
+++ b/src/eval.js
@@ -10,7 +10,7 @@ import _, {
 } from 'lodash';
 import vm from 'vm';
 
-const lodashContext = new vm.createContext(_);
+const lodashContext = new vm.createContext(Object.assign({}, _));
 
 export function evalChain(data, args, verbose) {
 


### PR DESCRIPTION
Newer node versions check the type of the sandbox. Lodash is a function object, but we only care about the properties. So assign those properties to a blank object.